### PR TITLE
Remove warning if RFS is included more than once

### DIFF
--- a/scss.scss
+++ b/scss.scss
@@ -202,11 +202,3 @@ $rfs-breakpoint-unit-cache: unit($rfs-breakpoint);
 @mixin responsive-font-size($fs, $important: false) {
   @include rfs($fs, $important);
 }
-
-$rfs-is-included: false !default;
-
-@if $rfs-is-included {
-  @warn "Watch out, RFS is included more than once!";
-}
-
-$rfs-is-included: true;

--- a/stylus.styl
+++ b/stylus.styl
@@ -172,10 +172,3 @@ rfs($fs, $important = false)
 // The responsive-font-size mixin uses RFS to rescale font sizes
 responsive-font-size($fs, $important = false)
   rfs($fs, $important)
-
-$rfs-is-included ?= false
-
-if $rfs-is-included
-  warn("Watch out, RFS is included more than once!")
-
-$rfs-is-included = true

--- a/test/lib/tests.js
+++ b/test/lib/tests.js
@@ -37,6 +37,6 @@ module.exports = [
   },
   {
     id: 'test-10',
-    name: 'Include mixins multiple times (Should throw a warning for SCSS & Stylus and not fail for less & PostCSS)'
+    name: 'Include mixins multiple times'
   },
 ];


### PR DESCRIPTION
This was a bit confusing for people including the mixin multiple times in Bootstrap.