### PR TITLE
Remove unneeded else conditions.

### DIFF
--- a/examples/less/node/index.js
+++ b/examples/less/node/index.js
@@ -16,9 +16,9 @@ less.render(
     fs.writeFile(path.join(__dirname, '/dest/main.css'), output.css, err => {
       if (err) {
         throw err;
-      } else {
-        console.log('Responsive font sizes generated.');
       }
+
+      console.log('Responsive font sizes generated.');
     });
   },
   error => {

--- a/examples/postcss/node/index.js
+++ b/examples/postcss/node/index.js
@@ -23,7 +23,7 @@ const processedCss = postcss(rfs(options)).process(css).css;
 fs.writeFile(path.join(__dirname, '/dest/main.css'), processedCss, err => {
   if (err) {
     throw err;
-  } else {
-    console.log('Responsive font sizes generated.');
   }
+
+  console.log('Responsive font sizes generated.');
 });

--- a/examples/scss/node/index.js
+++ b/examples/scss/node/index.js
@@ -10,15 +10,15 @@ sass.render({
 }, (error, result) => { // Node-style callback from v3.0.0 onwards
   if (error) {
     throw error;
-  } else {
-    // No errors during the compilation, write this result on the disk
-    fs.writeFile(path.join(__dirname, '/dest/main.css'), result.css, err => {
-      if (err) {
-        throw err;
-      } else {
-        console.log('Responsive font sizes generated.');
-      }
-    });
   }
+
+  // No errors during the compilation, write this result on the disk
+  fs.writeFile(path.join(__dirname, '/dest/main.css'), result.css, err => {
+    if (err) {
+      throw err;
+    }
+
+    console.log('Responsive font sizes generated.');
+  });
 }
 );

--- a/examples/stylus/node/index.js
+++ b/examples/stylus/node/index.js
@@ -11,13 +11,13 @@ stylus.render(str, {
 }, (err, css) => {
   if (err) {
     throw err;
-  } else {
-    fs.writeFile(path.join(__dirname, '/dest/main.css'), css, err => {
-      if (err) {
-        throw err;
-      } else {
-        console.log('Responsive font sizes generated.');
-      }
-    });
   }
+
+  fs.writeFile(path.join(__dirname, '/dest/main.css'), css, err => {
+    if (err) {
+      throw err;
+    }
+
+    console.log('Responsive font sizes generated.');
+  });
 });


### PR DESCRIPTION
If an error is thrown, execution won't move any further so this is redundant.