### PR TITLE
Remove duplicate explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If you're using Webpack, you can simplify the `@import` using the `~` prefix:
 
 ## Visualisation
 
-If you wonder how the font sizes are rescaled, wonder no more and stare at this graph which might clarify things a bit. The font sizes used on the graph are in `px`, but in reality RFS renders them in `rem` by default:
+If you wonder how the font sizes are rescaled, wonder no more and stare at this graph which might clarify things a bit:
 
 ![RFS visualisation](https://raw.githubusercontent.com/twbs/rfs/master/.github/rfs-graph.svg?sanitize=true)
 


### PR DESCRIPTION
This is also explained later on: 
> Note that every font size is generated in a combination of rem and vw units, but they are mapped to px in the graph to make it easier to understand.