### PR TITLE
Fix spaces before semicolon at set the calculated font-size part #154

### DIFF
--- a/scss.scss
+++ b/scss.scss
@@ -155,7 +155,7 @@ $rfs-breakpoint-unit-cache: unit($rfs-breakpoint);
       $variable-width: #{$fs-diff * 100 / $rfs-breakpoint}#{$variable-unit};
 
       // Set the calculated font-size
-      $rfs-fluid: calc(#{$min-width} + #{$variable-width}) #{$rfs-suffix};
+      $rfs-fluid: calc(#{$min-width} + #{$variable-width})#{$rfs-suffix};
 
       // Breakpoint formatting
       $mq-value: if($rfs-breakpoint-unit == px, #{$rfs-breakpoint}px, #{$rfs-breakpoint / $rfs-rem-value}#{$rfs-breakpoint-unit});


### PR DESCRIPTION
Thank you for RFS library
We started to adopt the library in one of our key product modules.

[Issue #3074888: Switch CSS management from LESS to SCSS with gulp and make use of the (RFS) Responsive Font Size SCSS library
](https://www.drupal.org/project/vmi/issues/3074888)

But in we do face an issue of standard coding standard practice on
 
**Expected 0 spaces before semicolon in style definition; 1 found**

The following
```
      // Set the calculated font-size
      $rfs-fluid: calc(#{$min-width} + #{$variable-width}) #{$rfs-suffix};
```

Could be
```

      // Set the calculated font-size
      $rfs-fluid: calc(#{$min-width} + #{$variable-width})#{$rfs-suffix};
```


for Example: in a SCSS file

```
.horizontal-media-teaser-view-mode.large {
  .field--name-node-title {
    h3 {
      @include font-size(1.8rem);
    }
  }
}

```

Will result of that in CSS file

```
.horizontal-media-teaser-view-mode.large .field--name-node-title h3 {
  font-size: 1.8rem;
}

@media (max-width: 1200px) {
  .horizontal-media-teaser-view-mode.large .field--name-node-title h3 {
    font-size: calc(1.305rem + 0.66vw) ;
  }
}
```

Expected 0 spaces before semicolon in style definition; 1 found

It should be
```
.horizontal-media-teaser-view-mode.large .field--name-node-title h3 {
  font-size: 1.8rem;
}

@media (max-width: 1200px) {
  .horizontal-media-teaser-view-mode.large .field--name-node-title h3 {
    font-size: calc(1.305rem + 0.66vw);
  }
}
```

Thank you :)

Fixes #154