### PR TITLE
Update stylelint.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
-      "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.2",
+        "@babel/generator": "^7.6.4",
         "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.2",
+        "@babel/parser": "^7.6.4",
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.2",
-        "@babel/types": "^7.6.0",
+        "@babel/traverse": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -53,12 +53,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
-      "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.0",
+        "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -116,9 +116,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
-      "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
       "dev": true
     },
     "@babel/template": {
@@ -133,17 +133,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
-      "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
+      "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.2",
+        "@babel/generator": "^7.6.3",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.2",
-        "@babel/types": "^7.6.0",
+        "@babel/parser": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -167,9 +167,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1921,9 +1921,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.277",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
-      "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+      "version": "1.3.280",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
+      "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -5249,9 +5249,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
-      "integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.16.0.tgz",
+      "integrity": "sha512-0g5vDDPvNnQk7WM/aE92dTDxXJoOE0biiIcUb3qkn/F6h/ZQZPlZIbE2XSXH2vFPfphkgCxuR2vH6HHnobEOaQ==",
       "dev": true
     },
     "last-run": {
@@ -6252,9 +6252,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.34",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.34.tgz",
-      "integrity": "sha512-fNn12JTEfniTuCqo0r9jXgl44+KxRH/huV7zM/KAGOKxDKrHr6EbT7SSs4B+DNxyBE2mks28AD+Jw6PkfY5uwA==",
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+      "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -7244,13 +7244,13 @@
       }
     },
     "postcss-sass": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.5.tgz",
-      "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.1.tgz",
+      "integrity": "sha512-YDdykeDHylqiD2CdXuP7K1aDz7hCflGVB6H6lqabWVab5mVOWhguUuWZYpFU22/E12AEGiMlOfZnLqr343zhVA==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
+        "gonzales-pe": "^4.2.4",
+        "postcss": "^7.0.14"
       }
     },
     "postcss-scss": {
@@ -8360,9 +8360,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz",
-      "integrity": "sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-11.1.1.tgz",
+      "integrity": "sha512-Vx6TAJsxG6qksiFvxQTKriQhp1CqUWdpTDITEkAjTR+l+8Af7qNlvrUDXfpuFJgXh/ayF8xdMSKE+SstcsPmMA==",
       "dev": true,
       "requires": {
         "autoprefixer": "^9.5.1",
@@ -8380,29 +8380,28 @@
         "ignore": "^5.0.6",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.14.0",
+        "known-css-properties": "^0.16.0",
         "leven": "^3.1.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "log-symbols": "^3.0.0",
         "mathml-tag-names": "^2.1.0",
         "meow": "^5.0.0",
         "micromatch": "^4.0.0",
         "normalize-selector": "^0.2.0",
-        "pify": "^4.0.1",
         "postcss": "^7.0.14",
         "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.1",
+        "postcss-jsx": "^0.36.3",
         "postcss-less": "^3.1.4",
         "postcss-markdown": "^0.36.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^4.0.1",
-        "postcss-sass": "^0.3.5",
+        "postcss-sass": "^0.4.1",
         "postcss-scss": "^2.0.0",
         "postcss-selector-parser": "^3.1.0",
         "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.1",
+        "postcss-value-parser": "^4.0.2",
         "resolve-from": "^5.0.0",
         "signal-exit": "^3.0.2",
         "slash": "^3.0.0",
@@ -8412,7 +8411,8 @@
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.2.3"
+        "table": "^5.2.3",
+        "v8-compile-cache": "^2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8534,14 +8534,6 @@
             "parse-json": "^4.0.0",
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            }
           }
         },
         "locate-path": {
@@ -8649,26 +8641,12 @@
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            }
           }
         },
         "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "read-pkg": {
@@ -8767,18 +8745,18 @@
       }
     },
     "stylelint-config-recommended": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.2.0.tgz",
-      "integrity": "sha512-bZ+d4RiNEfmoR74KZtCKmsABdBJr4iXRiCso+6LtMJPw5rd/KnxUWTxht7TbafrTJK1YRjNgnN0iVZaJfc3xJA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
       "dev": true
     },
     "stylelint-config-standard": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-18.3.0.tgz",
-      "integrity": "sha512-Tdc/TFeddjjy64LvjPau9SsfVRexmTFqUhnMBrzz07J4p2dVQtmpncRF/o8yZn8ugA3Ut43E6o1GtjX80TFytw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-19.0.0.tgz",
+      "integrity": "sha512-VvcODsL1PryzpYteWZo2YaA5vU/pWfjqBpOvmeA8iB2MteZ/ZhI1O4hnrWMidsS4vmEJpKtjdhLdfGJmmZm6Cg==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^2.2.0"
+        "stylelint-config-recommended": "^3.0.0"
       }
     },
     "stylus": {

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.18",
     "prettier": "^1.18.2",
-    "stylelint": "^10.1.0",
-    "stylelint-config-standard": "^18.3.0",
+    "stylelint": "^11.1.1",
+    "stylelint-config-standard": "^19.0.0",
     "stylus": "^0.54.7",
     "xo": "^0.25.3"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "mocha": "mocha",
-    "stylelint": "stylelint \"**/*.{less,sass,scss}\" --cache --cache-location node_modules/.cache/stylelint",
+    "stylelint": "stylelint \"**/*.{less,scss}\" --cache --cache-location node_modules/.cache/stylelint",
     "xo": "xo",
     "lint": "npm-run-all --parallel xo stylelint",
     "test": "npm run lint && npm run mocha",

--- a/scss.scss
+++ b/scss.scss
@@ -221,7 +221,7 @@ $rfs-mq-property-height: if($rfs-mode == max-media-query, max-height, min-height
           $variable-width: #{$value-diff * 100 / $rfs-breakpoint}#{$variable-unit};
 
           // Return the calculated value
-          $val: $val + ' ' + if($value < 0, calc(-#{$min-width} - #{$variable-width}), calc(#{$min-width} + #{$variable-width}));
+          $val: $val + ' calc(' + if($value < 0, -#{$min-width} - #{$variable-width}, #{$min-width} + #{$variable-width}) + ')';
         }
       }
     }


### PR DESCRIPTION
* stylelint to v11.1.1
* stylelint-config-standard to v19.0.0

This fails for reasons unknown to me:

```
C:\Users\xmr\Desktop\rfs>npm run stylelint

> rfs@9.0.0 stylelint C:\Users\xmr\Desktop\rfs
> stylelint "**/*.{less,sass,scss}" --cache --cache-location node_modules/.cache/stylelint

TypeError: Cannot read property 'start' of undefined
    at Rule.positionBy (C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\node.js:488:27)
    at module.exports (C:\Users\xmr\Desktop\rfs\node_modules\stylelint\lib\utils\report.js:49:34)
    at check (C:\Users\xmr\Desktop\rfs\node_modules\stylelint\lib\rules\block-no-empty\index.js:70:7)
    at C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\container.js:239:18
    at C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\container.js:135:18
    at Root.each (C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\container.js:101:16)
    at Root.walk (C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\container.js:131:17)
    at Root.walkRules (C:\Users\xmr\Desktop\rfs\node_modules\postcss\lib\container.js:237:19)
    at C:\Users\xmr\Desktop\rfs\node_modules\stylelint\lib\rules\block-no-empty\index.js:43:10
    at C:\Users\xmr\Desktop\rfs\node_modules\stylelint\lib\lintSource.js:247:13
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! rfs@9.0.0 stylelint: `stylelint "**/*.{less,sass,scss}" --cache --cache-location node_modules/.cache/stylelint`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the rfs@9.0.0 stylelint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\xmr\AppData\Roaming\npm-cache\_logs\2019-10-08T12_15_20_648Z-debug.log
```