### PR TITLE
Revert "Bump mocha from 6.2.1 to 6.2.2 (#171)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5922,9 +5922,9 @@
       }
     },
     "mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.1.tgz",
+      "integrity": "sha512-VCcWkLHwk79NYQc8cxhkmI8IigTIhsCwZ6RTxQsqK6go4UvEhzJkYuHm8B2YtlSxcYq2fY+ucr4JBwoD6ci80A==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",


### PR DESCRIPTION
This reverts commit 519c57c9c1f16f9c9d0235ca5c927fdd4472a660.

So that we test the new settings.