### PR TITLE
CI: remove no longer needed steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: node --version
-      - run: npm --version
-
       - name: Install npm dependencies
         run: npm ci
 


### PR DESCRIPTION
The latest `actions/setup-node` prints this info by default