### PR TITLE
README Documentation Typo Fix: 'space' -> 'comma'

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ project/
   // For properties which do not have a shorthand, the property can be passed:
   // @include rfs(4rem, border-radius);
 
-  // Whenever a value contains a space, it should be escaped with `#{}`:
+  // Whenever a value contains a comma, it should be escaped with `#{}`:
   // @include rfs(0 0 4rem red #{","} 0 0 5rem blue, box-shadow);
 
   // Custom properties (css variables):
@@ -189,7 +189,7 @@ project/
   // For properties which do not have a shorthand, the property can be passed:
   // +rfs(4rem, border-radius)
 
-  // Whenever a value contains a space, it should be escaped with `#{}`:
+  // Whenever a value contains a comma, it should be escaped with `#{}`:
   // +rfs(0 0 4rem red #{","} 0 0 5rem blue, box-shadow)
 
   // Custom properties (css variables):
@@ -329,7 +329,7 @@ project/
   // For properties which do not have a shorthand, the property can be passed as:
   // .rfs(4rem, border-radius);
 
-  // Whenever a value contains a space, it should be escaped with a tilde(~):
+  // Whenever a value contains a comma, it should be escaped with a tilde(~):
   // .rfs(0 0 4rem red ~"," 0 0 5rem blue, box-shadow)
 
   // Custom properties (css variables):
@@ -420,7 +420,7 @@ project/
   // For properties which do not have a shorthand, the property can be passed as:
   // rfs(4rem, border-radius)
 
-  // Whenever a value contains a space, it should be escaped with a backslash:
+  // Whenever a value contains a comma, it should be escaped with a backslash:
   // rfs(0 0 4rem red \, 0 0 5rem blue, box-shadow)
 
   // Custom properties (css variables):


### PR DESCRIPTION
Several examples in the README documentation mention escaping a space character, but then show escaping a comma character instead. This is a quick fix for those.

Note that I haven't gone through other files in the repo to check if they have that same or similar typos, so this may need adjusted elsewhere as well if this phrase was copy/pasted around in other documentation.