### PR TITLE
README: Change incorrect file extension scss->sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ project/
 #### Input
 
 ```sass
-// scss/main.scss
+// sass/main.sass
 
 @import "../node_modules/rfs/sass"
 


### PR DESCRIPTION
Change in the SASS example:
// scss/main.scss
to
// sass/main.sass
Since the folder structure given above clearly states that the sass/main.sass file is being edited