### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,3 @@ updates:
     labels:
       - dependencies
     versioning-strategy: increase
-    rebase-strategy: disabled


### PR DESCRIPTION
Remove `rebase-strategy: disabled`. This repo is fine with rebasing since it doesn't have BrowserStack.