### PR TITLE
Fix deprecation warning with Sass 1.77.7

### DIFF
--- a/scss.scss
+++ b/scss.scss
@@ -163,10 +163,6 @@ $rfs-mq-property-height: if($rfs-mode == max-media-query, max-height, min-height
 @mixin _rfs-media-query-rule {
 
   @if $rfs-class == enable {
-    @if $rfs-mode == min-media-query {
-      @content;
-    }
-
     @include _rfs-media-query () {
       .enable-rfs &,
       &.enable-rfs {
@@ -288,6 +284,10 @@ $rfs-mq-property-height: if($rfs-mode == max-media-query, max-height, min-height
       #{$property}: $val;
     }
     @else {
+      @if $rfs-class == enable and $rfs-mode == min-media-query {
+        #{$property}: if($rfs-mode == max-media-query, $fluid-val, $val);
+      }
+
       @include _rfs-rule () {
         #{$property}: if($rfs-mode == max-media-query, $val, $fluid-val);
 


### PR DESCRIPTION
> [!WARNING]  
> This PR is a draft probably tackling only a part of the problem

> [!WARNING]
> https://github.com/twbs/rfs/issues/474#issuecomment-2326633836 has not been tested out as it might be another issue

Closes #474

### Description

This PR is an attempt to fix #474.

<details>
<summary>Context</summary>

```
git checkout main
npm i sass@1.77.7
npm run test
```

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
153 │ ┌     .enable-rfs &,
154 │ │     &.enable-rfs {
155 │ │       @content;
156 │ │     }
    │ └─── nested rule
... │
299 │           #{$property}: if($rfs-mode == max-media-query, $fluid-val, $val);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    scss.scss 299:9            @content
    scss.scss 167:7            -rfs-media-query-rule()
    scss.scss 298:7            rfs()
    test/sass/_main.scss 38:5  @import
    test/sass/test-4.scss 2:9  root stylesheet

Warning: 18 repetitive deprecation warnings omitted.
```
</details>

The issue comes from our internal mixins `_rfs-rule` and `_rfs-media-query-rule` that can both render `@content;` without any selector; that causes for instance this kind of rules:

```scss
@content;

.enable-rfs &,
&.enable-rfs {
   @content;
}

@content;
```

Since there are supposed to be **internal mixins**, I supposed that I could modify them without any problems for users, and chose to only extract the problematic rule from `_rfs-media-query-rule`, and use it before calling `_rfs-rule`:

```scss
@if $rfs-class == enable {
    @if $rfs-mode == min-media-query {
      @content;
    }
}
```

Maybe there's a smarter way of doing it, but I'm not that familiar with this repo.
